### PR TITLE
関数定義と呼び出しを追加

### DIFF
--- a/src/main/java/jp/classmethod/toys/interpreter/Ast.java
+++ b/src/main/java/jp/classmethod/toys/interpreter/Ast.java
@@ -105,4 +105,9 @@ public class Ast {
   // Function 呼び出しは Expression を実装するのでどこから呼び出しても良い
   public static final record FunctionCall(String name, List<Expression> args)
       implements Expression {}
+
+  // Program
+  // https://github.com/toys-lang/toys/blob/master/src/main/java/com/github/kmizu/toys/Ast.java#L87
+  // SDには記載なかったっぽい
+  public static final record Program(List<TopLevel> definitions) {}
 }

--- a/src/main/java/jp/classmethod/toys/interpreter/Ast.java
+++ b/src/main/java/jp/classmethod/toys/interpreter/Ast.java
@@ -51,6 +51,28 @@ public class Ast {
     return new IfExpression(condition, thenClause, Optional.empty());
   }
 
+  public static IfExpression If(
+      Expression condition, Expression thenClause, Optional<Expression> elseClause) {
+    return new IfExpression(condition, thenClause, elseClause);
+  }
+
+  public static Identifier symbol(String n) {
+    return new Identifier(n);
+  }
+
+  public static BinaryExpression lessThan(Identifier lhs, Expression rhs) {
+    return new BinaryExpression(Operator.LESS_THAN, lhs, rhs);
+  }
+
+  public static FunctionCall call(String name, Expression... args) {
+    return new FunctionCall(name, List.of(args));
+  }
+
+  public static FunctionDefinition DefineFunction(
+      String name, List<String> expressions, BlockExpression block) {
+    return new FunctionDefinition(name, expressions, block);
+  }
+
   ////// 以下Expression定義
   public static final record BinaryExpression(Operator operator, Expression lhs, Expression rhs)
       implements Expression {}

--- a/src/main/java/jp/classmethod/toys/interpreter/Ast.java
+++ b/src/main/java/jp/classmethod/toys/interpreter/Ast.java
@@ -98,7 +98,7 @@ public class Ast {
 
   //// Environment
   public static final record Environment(
-      Map<String, Integer> bindings, Optional<Environment> next) {
+      Map<String, Values.Value> bindings, Optional<Environment> next) {
 
     /**
      * パラメータ名を Environment の中から探す。 bindings から name が存在するかどうかをチェック。なければ next で findBindings を実行
@@ -106,7 +106,7 @@ public class Ast {
      * @param name 登録してあるパラメータ名
      * @return {@link Optional}
      */
-    public Optional<Map<String, Integer>> findBinding(String name) {
+    public Optional<Map<String, Values.Value>> findBinding(String name) {
       if (bindings.get(name) != null) {
         return Optional.of(bindings);
       }

--- a/src/main/java/jp/classmethod/toys/interpreter/Ast.java
+++ b/src/main/java/jp/classmethod/toys/interpreter/Ast.java
@@ -12,6 +12,7 @@ public class Ast {
       permits Assignment,
           BinaryExpression,
           BlockExpression,
+          FunctionCall,
           Identifier,
           IfExpression,
           IntegerLiteral,
@@ -94,4 +95,14 @@ public class Ast {
       }
     }
   }
+
+  public sealed interface TopLevel permits FunctionDefinition {}
+
+  // Function 定義は TopLevel でしかダメ
+  public static final record FunctionDefinition(String name, List<String> args, Expression body)
+      implements TopLevel {}
+
+  // Function 呼び出しは Expression を実装するのでどこから呼び出しても良い
+  public static final record FunctionCall(String name, List<Expression> args)
+      implements Expression {}
 }

--- a/src/main/java/jp/classmethod/toys/interpreter/Interpreter.java
+++ b/src/main/java/jp/classmethod/toys/interpreter/Interpreter.java
@@ -40,10 +40,10 @@ public class Interpreter {
         case DIVIDE -> Values.wrap(lhs / rhs);
 
           // 比較式
-        case LESS_THAN -> Values.wrap(lhs > rhs);
-        case LESS_OR_EQUAL -> Values.wrap(lhs >= rhs);
-        case GREATER_THAN -> Values.wrap(lhs < rhs);
-        case GREATER_OR_EQUAL -> Values.wrap(lhs <= rhs);
+        case LESS_THAN -> Values.wrap(lhs < rhs);
+        case LESS_OR_EQUAL -> Values.wrap(lhs <= rhs);
+        case GREATER_THAN -> Values.wrap(lhs > rhs);
+        case GREATER_OR_EQUAL -> Values.wrap(lhs >= rhs);
         case EQUAL_EQUAL -> Values.wrap(lhs == rhs);
         case NOT_EQUAL -> Values.wrap(lhs != rhs);
       };

--- a/src/main/java/jp/classmethod/toys/interpreter/LanguageException.java
+++ b/src/main/java/jp/classmethod/toys/interpreter/LanguageException.java
@@ -1,0 +1,9 @@
+/* Copyright (C) 2023 komuro-hiraku */
+package jp.classmethod.toys.interpreter;
+
+// https://github.com/toys-lang/toys/blob/master/src/main/java/com/github/kmizu/toys/LanguageException.java
+public class LanguageException extends RuntimeException {
+  public LanguageException(String s) {
+    super(s);
+  }
+}

--- a/src/main/java/jp/classmethod/toys/interpreter/Values.java
+++ b/src/main/java/jp/classmethod/toys/interpreter/Values.java
@@ -1,0 +1,51 @@
+/* Copyright (C) 2023 komuro-hiraku */
+package jp.classmethod.toys.interpreter;
+
+import java.util.List;
+import java.util.Map;
+
+public class Values {
+
+  public sealed interface Value permits Int, Bool, Array, Dictionary {
+    default Int asInt() {
+      return (Int) this;
+    }
+
+    default Bool asBool() {
+      return (Bool) this;
+    }
+
+    default Array asArray() {
+      return (Array) this;
+    }
+
+    default Dictionary asDictionary() {
+      return (Dictionary) this;
+    }
+  }
+
+  public static final record Int(int value) implements Value {}
+
+  public static final record Bool(boolean value) implements Value {}
+
+  public static final record Array(List<? extends Value> values) implements Value {}
+
+  public static final record Dictionary(Map<? extends Value, ? super Value> entries)
+      implements Value {}
+
+  public static Value wrap(Object javaValue) {
+    if (javaValue instanceof Integer val) {
+      return new Int(val);
+    }
+    if (javaValue instanceof Boolean val) {
+      return new Bool(val);
+    }
+    if (javaValue instanceof List<?> val) {
+      return new Array((List<Value>) val);
+    }
+    if (javaValue instanceof Map<?, ?> val) {
+      return new Dictionary((Map<Value, Value>) val);
+    }
+    throw new LanguageException("must not reach here");
+  }
+}

--- a/src/test/java/jp/classmethod/toys/interpreter/InterpreterTest.java
+++ b/src/test/java/jp/classmethod/toys/interpreter/InterpreterTest.java
@@ -1,10 +1,11 @@
 /* Copyright (C) 2023 komuro-hiraku */
 package jp.classmethod.toys.interpreter;
 
-import static jp.classmethod.toys.interpreter.Ast.add;
-import static jp.classmethod.toys.interpreter.Ast.integer;
+import static jp.classmethod.toys.interpreter.Ast.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class InterpreterTest {
@@ -15,5 +16,34 @@ class InterpreterTest {
   public void test10Plus20ShouldWork() {
     Ast.Expression e = add(integer(10), integer(20));
     assertEquals(30, interpreter.interpret(e));
+  }
+
+  @Test
+  public void testFactorial() {
+    List<Ast.TopLevel> topLevels =
+        List.of(
+            // define main() {
+            //    fact(5);
+            // }
+            Ast.DefineFunction("main", List.of(), Block(Ast.call("fact", integer(5)))),
+            // define fact(n) {
+            //  if (n < 2) {
+            //    1;
+            //  } else {
+            //    n + fact(n - 1);
+            //  }
+            // }
+            DefineFunction(
+                "fact",
+                List.of("n"),
+                Block(
+                    If(
+                        Ast.lessThan(Ast.symbol("n"), integer(2)),
+                        integer(1),
+                        Optional.of(
+                            multiply(
+                                symbol("n"), call("fact", subtract(symbol("n"), integer(1)))))))));
+    int result = interpreter.callMain(new Ast.Program(topLevels));
+    assertEquals(120, result);
   }
 }

--- a/src/test/java/jp/classmethod/toys/interpreter/InterpreterTest.java
+++ b/src/test/java/jp/classmethod/toys/interpreter/InterpreterTest.java
@@ -15,7 +15,7 @@ class InterpreterTest {
   @Test
   public void test10Plus20ShouldWork() {
     Ast.Expression e = add(integer(10), integer(20));
-    assertEquals(30, interpreter.interpret(e));
+    assertEquals(30, interpreter.interpret(e).asInt().value());
   }
 
   @Test

--- a/src/test/java/jp/classmethod/toys/interpreter/InterpreterTest.java
+++ b/src/test/java/jp/classmethod/toys/interpreter/InterpreterTest.java
@@ -43,7 +43,7 @@ class InterpreterTest {
                         Optional.of(
                             multiply(
                                 symbol("n"), call("fact", subtract(symbol("n"), integer(1)))))))));
-    int result = interpreter.callMain(new Ast.Program(topLevels));
-    assertEquals(120, result);
+    var result = interpreter.callMain(new Ast.Program(topLevels));
+    assertEquals(120, result.asInt().value());
   }
 }


### PR DESCRIPTION
# 概要

関数定義と呼び出しを追加する

# やること

- 関数呼び出し、関数定義の構文を追加
- Interpreter 内に関数呼び出しのコードを追加
- `Ast.Environment` の実装
- 単なる `Map<String, Integer>` の Environment を上記 `Ast.Environment` を利用するよう修正する
    - lhs, rhs あたりの修正
    - Identifier あたりの修正
    - Assignment あたりの修正